### PR TITLE
sepolicy: Allow exfat and ntfs access for sdcard

### DIFF
--- a/untrusted_app.te
+++ b/untrusted_app.te
@@ -189,9 +189,11 @@ neverallow untrusted_app {
   -sdcardfs                 # sdcard
   -vfat
 
-# For exfat and f2fs/ext4 sdcards via sdcardfs
+# For exfat, f2fs/ext4, and ntfs storage via sdcardfs
 ifelse(shipping_build, `true', ,`
+  -exfat
   -fuseblk
+  -ntfs
   -sdcard_posix
 ')
 


### PR DESCRIPTION
* This is necessary if using kernel exfat or ntfs for external sdcard
  or USB OTG
* This exception is only valid on non-shipping builds

Change-Id: I1f3025f28ef6d22f4e1c0d73e0edcccf59e3101d